### PR TITLE
Use GITHUB_TOKEN for GHCR docker publish

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -48,11 +48,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT2  }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |


### PR DESCRIPTION
## Summary

Replace the missing `GHCR_PAT2` secret with the workflow-provided `GITHUB_TOKEN` for GHCR login. The workflow already declares `packages: write`.

Also uses `github.repository_owner` (OWASP) as the registry username instead of `github.actor`.

Related to #7, #8

## Why

Main CI passed tests after #11 but docker-build failed with:

```
Username and password required
```

because `secrets.GHCR_PAT2` is not configured.

## Test plan

- [ ] PR CI: lint + tests pass
- [ ] After merge: `CI + Docker Build & Push` on `main` publishes `ghcr.io/owasp/pwnzzai:latest`
- [ ] `docker pull ghcr.io/owasp/pwnzzai:latest` succeeds


Made with [Cursor](https://cursor.com)