### PR TITLE
fix(docker): use a CPU-only PyTorch image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,13 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN python -m pip install --upgrade pip && \
     pip install \
     --retries 10 \
     --timeout 600 \
+    --index-url https://download.pytorch.org/whl/cpu \
+    torch==2.7.1 && \
+    pip install \
+    --retries 10 \
+    --timeout 600 \
     -r requirements.txt
 
 COPY . .
@@ -25,5 +30,5 @@ ENV FLASK_APP=main.py
 ENV PYTHONUNBUFFERED=1
 ENV OLLAMA_HOST=http://ollama:11434
 
-# Start Ollama in background, wait for it, then start Flask
-CMD ollama serve > /tmp/ollama.log 2>&1 & sleep 5 && flask run --host=0.0.0.0 --port=8080 --no-reload
+# Ollama runs in its own Compose service or at OLLAMA_HOST.
+CMD ["flask", "run", "--host=0.0.0.0", "--port=8080", "--no-reload"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-# CI workflow ignores these; keep aligned.
+# Keep the CI contract stable across Ruff releases instead of inheriting
+# version-dependent defaults.
+select = ["E4", "E7", "E9", "F"]
 ignore = ["E402", "F401", "F841"]

--- a/tests/unit/test_dockerfile.py
+++ b/tests/unit/test_dockerfile.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).parents[2] / "Dockerfile"
+
+
+def test_docker_image_installs_cpu_only_torch_before_app_requirements():
+    contents = DOCKERFILE.read_text()
+
+    cpu_index = contents.index("https://download.pytorch.org/whl/cpu")
+    requirements_install = contents.index("-r requirements.txt")
+
+    assert cpu_index < requirements_install
+    assert "torch==2.7.1" in contents[cpu_index:requirements_install]
+
+
+def test_app_image_does_not_start_a_second_ollama_server():
+    command = next(
+        line for line in DOCKERFILE.read_text().splitlines() if line.startswith("CMD ")
+    )
+
+    assert "ollama serve" not in command
+    assert command.startswith('CMD ["flask", "run"')


### PR DESCRIPTION
## Summary

- install the CPU-only PyTorch wheel instead of CUDA runtime dependencies
- rely on the separate Ollama service rather than starting a nonexistent embedded daemon
- stabilize Ruff linting across releases
- add packaging regression tests

Fixes #6.

## Validation

- native arm64 container build passes
- image size falls from the published 6.11 GB manifest to 776.6 MB locally (87.3% smaller)
- 204 tests pass and 65 are skipped
- installed PyTorch reports no CUDA support
- the exact CPython 3.11 x86_64 CPU wheel resolves successfully; local x86 execution was unavailable because this Docker installation lacks amd64 emulation
- Ruff, Compose validation, and actionlint pass

## AI assistance

OpenAI Codex assisted with the audit, implementation, tests, and PR description. I reviewed the complete diff and validation results.