### PR TITLE
perf: shrink app image and speed Docker CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -56,6 +56,13 @@ docker-compose.yml
 # Documentation
 *.md
 
+# Not needed at runtime (make test-docker bind-mounts tests/ + pytest.ini)
+tests/
+docs/
+deploy/
+scripts/
+.github/
+
 # Testing
 .pytest_cache/
 .coverage

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -3,39 +3,25 @@ name: CI + Docker Build & Push
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '**/*.md'
   workflow_dispatch:
 
 permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libzbar0
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
-
-      - name: Run tests
-        run: pytest -v
+    uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
 
   docker-build:
     needs: test

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -54,14 +57,21 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image
-        run: |
-          docker build \
-            -t ghcr.io/owasp/pwnzzai:latest \
-            -t ghcr.io/owasp/pwnzzai:${{ github.sha }} \
-            .
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/owasp/pwnzzai
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.sha }}
 
-      - name: Push Docker image
-        run: |
-          docker push ghcr.io/owasp/pwnzzai:latest
-          docker push ghcr.io/owasp/pwnzzai:${{ github.sha }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,17 +2,29 @@ name: Lint
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '**/*.md'
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,21 @@
 name: Run Tests
 
-on: 
-  push:
-    branches: [main]
+on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '**/*.md'
+  workflow_dispatch:
+  workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -17,8 +27,12 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5
-        with: 
+        with:
           python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-test.txt
 
       - name: Install System Dependencies
         run: |
@@ -30,9 +44,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-test.txt
-          
 
       - name: Run Tests
-        run: pytest -v 
-
-
+        run: pytest -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
+# CPU torch first so sentence-transformers does not pull the CUDA wheel (~GB of nvidia-*).
+# Do not pin torch in requirements.txt: host/macOS venvs stay unchanged.
 RUN python -m pip install --upgrade --no-cache-dir pip && \
-    pip install --no-cache-dir \
-    --retries 10 \
-    --timeout 600 \
-    -r requirements.txt
+    pip install --no-cache-dir --retries 10 --timeout 600 \
+      torch --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir --retries 10 --timeout 600 \
+      -r requirements.txt
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+# libzbar0: runtime for pyzbar (QR labs). Wheels cover numpy/sklearn/Pillow/faiss; no compiler.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libzbar0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ EXPOSE 8080
 
 ENV FLASK_APP=main.py
 ENV PYTHONUNBUFFERED=1
+# Compose DNS to the separate ollama service (not installed in this image).
 ENV OLLAMA_HOST=http://ollama:11434
 
-# Start Ollama in background, wait for it, then start Flask
-CMD ollama serve > /tmp/ollama.log 2>&1 & sleep 5 && flask run --host=0.0.0.0 --port=8080 --no-reload
+# Flask only. Ollama runs as compose service ollama/ollama:latest.
+CMD ["flask", "run", "--host=0.0.0.0", "--port=8080", "--no-reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y build-essential \
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
     libzbar0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN python -m pip install --upgrade pip && \
-    pip install \
+RUN python -m pip install --upgrade --no-cache-dir pip && \
+    pip install --no-cache-dir \
     --retries 10 \
     --timeout 600 \
     -r requirements.txt

--- a/Dockerfile.ollama
+++ b/Dockerfile.ollama
@@ -1,7 +1,0 @@
-FROM ollama/ollama:latest
-
-EXPOSE 11434
-
-ENV OLLAMA_KEEP_ALIVE=-1
-
-CMD ["ollama", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -136,13 +136,21 @@ test-docker-build: ## Build $(TEST_IMAGE) from Dockerfile for test runs
 	docker build -t "$(TEST_IMAGE)" .
 
 .PHONY: test-docker
-test-docker: test-docker-build ## Run pytest -v inside $(TEST_IMAGE) (installs requirements-test in container)
-	docker run --rm -t "$(TEST_IMAGE)" \
+test-docker: test-docker-build ## Run pytest -v inside $(TEST_IMAGE) (bind-mounts tests; image excludes tests/)
+	docker run --rm -t \
+		-v "$(CURDIR)/tests:/app/tests:ro" \
+		-v "$(CURDIR)/pytest.ini:/app/pytest.ini:ro" \
+		-v "$(CURDIR)/requirements-test.txt:/app/requirements-test.txt:ro" \
+		"$(TEST_IMAGE)" \
 		sh -lc 'python -m pip install -q -r requirements-test.txt && pytest -v'
 
 .PHONY: test-docker-cov
-test-docker-cov: test-docker-build ## pytest with coverage inside container
-	docker run --rm -t "$(TEST_IMAGE)" \
+test-docker-cov: test-docker-build ## pytest with coverage inside container (bind-mounts tests)
+	docker run --rm -t \
+		-v "$(CURDIR)/tests:/app/tests:ro" \
+		-v "$(CURDIR)/pytest.ini:/app/pytest.ini:ro" \
+		-v "$(CURDIR)/requirements-test.txt:/app/requirements-test.txt:ro" \
+		"$(TEST_IMAGE)" \
 		sh -lc 'python -m pip install -q -r requirements-test.txt && pytest --cov=application --cov-report=term-missing -v'
 
 # =============================================================================

--- a/deploy/Dockerfile.pwnzzai-workshop
+++ b/deploy/Dockerfile.pwnzzai-workshop
@@ -13,11 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
+# CPU torch first so sentence-transformers does not pull the CUDA wheel (~GB of nvidia-*).
 RUN python -m pip install --upgrade --no-cache-dir pip && \
-    pip install --no-cache-dir \
-    --retries 10 \
-    --timeout 600 \
-    -r requirements.txt
+    pip install --no-cache-dir --retries 10 --timeout 600 \
+      torch --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir --retries 10 --timeout 600 \
+      -r requirements.txt
 
 COPY . .
 

--- a/deploy/Dockerfile.pwnzzai-workshop
+++ b/deploy/Dockerfile.pwnzzai-workshop
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN python -m pip install --upgrade pip && \
-    pip install \
+RUN python -m pip install --upgrade --no-cache-dir pip && \
+    pip install --no-cache-dir \
     --retries 10 \
     --timeout 600 \
     -r requirements.txt

--- a/deploy/Dockerfile.pwnzzai-workshop
+++ b/deploy/Dockerfile.pwnzzai-workshop
@@ -7,7 +7,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+# libzbar0: runtime for pyzbar (QR labs). Wheels cover numpy/sklearn/Pillow/faiss; no compiler.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libzbar0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- App image starts Flask only. Ollama stays the separate Compose service (`ollama/ollama:latest`); unused `Dockerfile.ollama` is removed.
- Install CPU PyTorch from the PyTorch CPU index before `requirements.txt` so `sentence-transformers` does not pull the CUDA wheel. `requirements.txt` stays unpinned so host/macOS venvs are unchanged.
- Drop pip's download cache, apt recommended packages, and `build-essential` (wheels cover the Python deps). Keep `libzbar0` for QR labs.
- `.dockerignore` keeps tests/docs/CI out of the published image; `make test-docker` bind-mounts tests.
- CI: Buildx + GitHub Actions cache for GHCR pushes; pytest runs once via `test.yml` (3.12 + test extras); docs-only changes skip test/lint/image jobs; lint Actions match test (`checkout@v4`, `setup-python@v5`).

Lab Python is unchanged.

### Image size (linux/arm64 local build)

| | `docker images` | `docker inspect` `.Size` |
|--|-----------------|--------------------------|
| Published `ghcr.io/owasp/pwnzzai:latest` | 15.3 GB | 6.11 GB |
| This branch | **2.04 GB** | **441 MB** |

Installed torch is CPU-only (`2.13.0+cpu` on this machine; unpinned). MiniLM encode still returns `(1, 384)`.

## Test plan

- [x] `make test-docker` (pytest in the rebuilt image): 202 passed, 65 skipped
- [x] Image `CMD` is Flask only; no `ollama` / `gcc` / `tests/` in the image
- [x] Workflow YAML and both Compose files parse; `ci-docker.yml` calls `test.yml` then Buildx push
- [x] Local sanity: `/`, `/basics`, `/login`, Ollama status, QR decode, RAG query, `docker-smoke-test.sh` Option 1 + 2
- [ ] GitHub Actions on this PR: lint + test
- [ ] After merge: GHCR `latest` pull on linux/amd64 and `docker compose up` (`/` and `/check-ollama-status`)